### PR TITLE
KYP-1582: Move away from Pipedrive deprecated APIs

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -81,7 +81,7 @@ module Pipedrive
       end
 
       def new_list( attrs )
-        attrs['data'].is_a?(Array) ? attrs['data'].map {|data| self.new( 'data' => data ) } : []
+        attrs['data']['items'].is_a?(Array) ? attrs['data']['items'].map {|data| self.new( 'data' => data['item'] ) } : []
       end
 
       def all(response = nil, options={},get_absolutely_all=false)
@@ -114,7 +114,7 @@ module Pipedrive
       end
 
       def find_by_name(name, opts={})
-        res = get "#{resource_path}/find", :query => { :term => name }.merge(opts)
+        res = get "#{resource_path}/search", :query => { :term => name }.merge(opts)
         res.ok? ? new_list(res) : bad_response(res,{:name => name}.merge(opts))
       end
 


### PR DESCRIPTION
I've remove Murry's commit since most of it was not used.
Besides updating the endpoint from /find to /search I had to modify the result parsing since the new endpoint returns a bit different data. Already tested and seems working

===

Jira story [#KYP-1582](https://metrilojira.atlassian.net/browse/KYP-1582) in project *Know Your Power*:

> There are changes to the Pipedrive API that our library won't support and it'll break our integration.
> [https://pipedrive.readme.io/docs/changelog#removal-of-the-/find-/searchresults-and-/searchresults/field-endpoints-replaced-by-6-new-endpoints|https://pipedrive.readme.io/docs/changelog#removal-of-the-/find-/searchresults-and-/searchresults/field-endpoints-replaced-by-6-new-endpoints]
> 
> We're using at least one of these endpoints:
> `Pipedrive::Organization.find_by_name(name).first`
> Which calls `/organisation/find`