### PR TITLE
KYP-1582: Move away from Pipedrive deprecated APIs

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -73,7 +73,6 @@ module Pipedrive
       #
       # @param [HTTParty::Response] response
       def bad_response(response, params={})
-        puts params.inspect
         if response.class == HTTParty::Response
           raise HTTParty::ResponseError, response
         end
@@ -81,7 +80,9 @@ module Pipedrive
       end
 
       def new_list( attrs )
-        attrs['data']['items'].is_a?(Array) ? attrs['data']['items'].map {|data| self.new( 'data' => data['item'] ) } : []
+        return [] unless attrs['data']['items'].is_a?(Array)
+
+        attrs['data']['items'].map {|data| self.new( 'data' => data['item'] ) }
       end
 
       def all(response = nil, options={},get_absolutely_all=false)

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -15,8 +15,8 @@ module Pipedrive
   class Base < OpenStruct
 
     include HTTParty
-
-    base_uri 'https://api.pipedrive.com/v1'
+    
+    base_uri 'api.pipedrive.com/v1'
     headers HEADERS
     format :json
 
@@ -73,7 +73,7 @@ module Pipedrive
       #
       # @param [HTTParty::Response] response
       def bad_response(response, params={})
-        raise response.inspect
+        puts params.inspect
         if response.class == HTTParty::Response
           raise HTTParty::ResponseError, response
         end
@@ -104,69 +104,18 @@ module Pipedrive
           res['data'] = opts.merge res['data']
           new(res)
         else
-          puts opts.inspect
           bad_response(res,opts)
         end
       end
-
+      
       def find(id)
         res = get "#{resource_path}/#{id}"
         res.ok? ? new(res) : bad_response(res,id)
       end
 
-      def find_by_id(id)
-        res = get "#{resource_path}/#{id}"
-        res.ok? ? new(res) : false
-      end
-
-      def find_or_create_by_id(id, opts = {})
-        find_by_id(id) || create(opts)
-      end
-
-      def update_or_create_by_id(id, opts = {})
-        puts "trying to create or update by (id, opts)"
-        puts id.inspect
-        puts opts.inspect
-        puts "trying to fetch resource by id"
-        res = find_by_id id
-        puts "find_by_id result is:"
-        puts res.inspect
-        if res
-          puts "updating..."
-          res.update(opts)
-        else
-          puts "creating..."
-          create(opts)
-        end
-      end
-
-      def update_or_create_by_email(email, opts = {})
-        res = find_by_email email
-        if res
-          res.update(opts)
-        else
-          create(opts)
-        end
-      end
-
-      def update_or_create_by_name(name, opts = {})
-        res = find_by_name name
-        if res
-          res.update(opts)
-        else
-          create(opts)
-        end
-      end
-
-
       def find_by_name(name, opts={})
         res = get "#{resource_path}/find", :query => { :term => name }.merge(opts)
-        res.ok? ? new_list(res).first : false
-      end
-
-      def find_by_email(email, opts={})
-        res = get "#{resource_path}/find", :query => { :term => email, :search_by_email => 1}.merge(opts)
-        res.ok? ? new_list(res).first : false
+        res.ok? ? new_list(res) : bad_response(res,{:name => name}.merge(opts))
       end
 
       def resource_path

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -81,7 +81,7 @@ module Pipedrive
       end
 
       def new_list( attrs )
-        attrs['data'].is_a?(Array) ? attrs['data'].map {|data| self.new( 'data' => data ) } : []
+        attrs['data']['items'].is_a?(Array) ? attrs['data']['items'].map {|data| self.new( 'data' => data['item'] ) } : []
       end
 
       def all(response = nil, options={},get_absolutely_all=false)
@@ -114,7 +114,7 @@ module Pipedrive
       end
 
       def find_by_name(name, opts={})
-        res = get "#{resource_path}/find", :query => { :term => name }.merge(opts)
+        res = get "#{resource_path}/search", :query => { :term => name }.merge(opts)
         res.ok? ? new_list(res) : bad_response(res,{:name => name}.merge(opts))
       end
 


### PR DESCRIPTION
I've remove Murry's commit since most of it was not used.
Besides updating the endpoint from /find to /search I had to modify the result parsing since the new endpoint returns a bit different data. Already tested and seems working

===

Jira story [#KYP-1582](https://metrilojira.atlassian.net/browse/KYP-1582) in project *Know Your Power*:

> There are changes to the Pipedrive API that our library won't support and it'll break our integration.
> [https://pipedrive.readme.io/docs/changelog#removal-of-the-/find-/searchresults-and-/searchresults/field-endpoints-replaced-by-6-new-endpoints|https://pipedrive.readme.io/docs/changelog#removal-of-the-/find-/searchresults-and-/searchresults/field-endpoints-replaced-by-6-new-endpoints]
> 
> We're using at least one of these endpoints:
> `Pipedrive::Organization.find_by_name(name).first`
> Which calls `/organisation/find`